### PR TITLE
chore: lint workflows in CI

### DIFF
--- a/.github/workflows/lint_workflows.yaml
+++ b/.github/workflows/lint_workflows.yaml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint_workflows:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint Workflows
+        uses: diamondlightsource/workflows@main

--- a/.workflows-lint.yaml
+++ b/.workflows-lint.yaml
@@ -1,0 +1,2 @@
+charts:
+  - I15-1_workflows

--- a/I15-1_workflows/templates/i15-1-notebook-test.yaml
+++ b/I15-1_workflows/templates/i15-1-notebook-test.yaml
@@ -3,6 +3,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: ClusterWorkflowTemplate
 metadata:
   name: i15-1-notebook-test
+  labels:
+    workflows.diamond.ac.uk/science-group-crystallography: "true"
+  annotations:
+    workflows.diamond.ac.uk/repository: "https://github.com/DiamondLightSource/crystallography-workflows"
 spec:
   entrypoint: notebook
   arguments:


### PR DESCRIPTION
Enable linting of workflows in CI.

This helps to prevent broken ClusterWorkflowTemplates getting synced into the workflows system.